### PR TITLE
Add Lot.minimumValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ In the European Union, this extension's fields correspond to [eForms BT-99 (Revi
       "publicPassengerTransportServicesKilometers": 765,
       "awardID": "award-1"
     }
+  ],
+  "lots": [
+    {
+      "id": "lot-1",
+      "minimumValue": {
+        "amount": "12000",
+        "currency": "EUR"
+      }
+    }
   ]
 }
 ```
@@ -89,6 +98,10 @@ In the European Union, this extension's fields correspond to [eForms BT-99 (Revi
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2020-10-05
+
+* add `minimumValue` field to `Lot`.
 
 ### 2020-07-13
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ In the European Union, this extension's fields correspond to [eForms BT-99 (Revi
         }
       }
     ],
+    "lots": [
+      {
+        "id": "lot-1",
+        "minimumValue": {
+          "amount": "12000",
+          "currency": "EUR"
+        }
+      }
+    ],
     "milestones": [
       {
         "id": "1",
@@ -79,15 +88,6 @@ In the European Union, this extension's fields correspond to [eForms BT-99 (Revi
       "periodRationale": "The duration of the contract has been extended to anticipate the exceptional snowfall expected in January.",
       "publicPassengerTransportServicesKilometers": 765,
       "awardID": "award-1"
-    }
-  ],
-  "lots": [
-    {
-      "id": "lot-1",
-      "minimumValue": {
-        "amount": "12000",
-        "currency": "EUR"
-      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In the European Union, this extension's fields correspond to [eForms BT-99 (Revi
       {
         "id": "lot-1",
         "minimumValue": {
-          "amount": "12000",
+          "amount": 12000,
           "currency": "EUR"
         }
       }

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2020-10-05
 
-* add `minimumValue` field to `Lot`.
+* Add `Lot.minimumValue` field
 
 ### 2020-07-13
 

--- a/extension.json
+++ b/extension.json
@@ -23,7 +23,7 @@
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"
   },
-  "dependencies": [
+  "testDependencies": [
     "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
   ]
 }

--- a/extension.json
+++ b/extension.json
@@ -22,5 +22,8 @@
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"
-  }
+  },
+  "dependencies": [
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+  ]
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -145,10 +145,7 @@
         "minimumValue": {
           "title": "Minimum value",
           "description": "The minimum estimated value of the procurement. A negative value indicates that the contracting process may involve payments from the supplier to the buyer (commonly used in concession contracts).",
-          "type": [
-            "number",
-            "null"
-          ]
+          "$ref": "#/definitions/Value"
         }
       }
     }

--- a/release-schema.json
+++ b/release-schema.json
@@ -139,6 +139,18 @@
           "$ref": "#/definitions/ContactPoint"
         }
       }
+    },
+    "Lot": {
+      "properties": {
+        "minimumValue": {
+          "title": "Minimum value",
+          "description": "The minimum estimated value of the procurement. A negative value indicates that the contracting process may involve payments from the supplier to the buyer (commonly used in concession contracts).",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      }
     }
   }
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -148,7 +148,7 @@
       "properties": {
         "minimumValue": {
           "title": "Minimum value",
-          "description": "The minimum estimated value of the procurement. A negative value indicates that the contracting process may involve payments from the supplier to the buyer (commonly used in concession contracts).",
+          "description": "The minimum estimated value of the lot. A negative value indicates that the contracting process may involve payments from the supplier to the buyer (commonly used in concession contracts).",
           "$ref": "#/definitions/Value"
         }
       }

--- a/release-schema.json
+++ b/release-schema.json
@@ -30,7 +30,8 @@
             "$ref": "#/definitions/LegislativeReference"
           },
           "uniqueItems": true,
-          "wholeListMerge": true
+          "wholeListMerge": true,
+          "minItems": 1
         }
       }
     },
@@ -107,7 +108,8 @@
             "$ref": "#/definitions/Address"
           },
           "uniqueItems": true,
-          "wholeListMerge": true
+          "wholeListMerge": true,
+          "minItems": 1
         }
       }
     },
@@ -122,7 +124,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "minLength": 1
         },
         "url": {
           "title": "URL",
@@ -138,7 +141,8 @@
           "description": "The contact details of an administrative service that can provide information about the legislative reference.",
           "$ref": "#/definitions/ContactPoint"
         }
-      }
+      },
+      "minProperties": 1
     },
     "Lot": {
       "properties": {


### PR DESCRIPTION
Here is the description I used, the same as `tender.minValue`:

> "The minimum estimated value of the procurement. A negative value indicates that the contracting process may involve payments from the supplier to the buyer (commonly used in concession contracts).

Should I replace "value of the procurement" with "value of the lot"?

Closes https://github.com/open-contracting-extensions/european-union/issues/78