### PR TITLE
Add awardPeriod to Lot

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ In the European Union, this extension's fields correspond to [eForms BT-99 (Revi
         "minimumValue": {
           "amount": 12000,
           "currency": "EUR"
+        },
+        "awardPeriod": {
+          "durationInDays": 30,
+          "startDate": "2020-11-06T00:00:00Z",
+          "endDate": "2020-12-06T00:00:00Z"
         }
       }
     ],
@@ -99,9 +104,13 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ## Changelog
 
+### 2020-10-06
+
+* add `awardPeriod` field to the `Lot` object.
+
 ### 2020-10-05
 
-* add `minimumValue` field to `Lot`.
+* add `minimumValue` field to the `Lot` object.
 
 ### 2020-07-13
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -150,6 +150,11 @@
           "title": "Minimum value",
           "description": "The minimum estimated value of the lot. A negative value indicates that the contracting process may involve payments from the supplier to the buyer (commonly used in concession contracts).",
           "$ref": "#/definitions/Value"
+        },
+        "awardPeriod": {
+          "title": "Award period",
+          "description": "The period for decision making regarding the contract award for the lot. The end date should be the date on which an award decision is due to be finalized. The start date may be used to indicate the start of an evaluation period.",
+          "$ref": "#/definitions/Period"
         }
       }
     }


### PR DESCRIPTION
I have reused the description of `tender.awardPeriod` and added "for the lot":

> The period for decision making regarding the contract award **for the lot**. The end date should be the date on which an award decision is due to be finalized. The start date may be used to indicate the start of an evaluation period.

Closes https://github.com/open-contracting-extensions/european-union/issues/81