### PR TITLE
release-schema: create SelectionCriteria.sources and ExclusionGrounds…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,17 @@ For complete guidance on meeting the disclosure requirements of European law, se
         "id": "Fiscal1",
         "documentType": "legislation"
       }
-    ]
+    ],
+    "selectionCriteria": {
+      "sources": [
+        "epo-notice"
+      ]
+    },
+    "exclusionGrounds": {
+      "sources": [
+        "epo-notice"
+      ]
+    }
   },
   "awards": [
     {
@@ -165,6 +175,13 @@ For complete guidance on meeting the disclosure requirements of European law, se
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2024-10-08
+
+* Add fields:
+  * `SelectionCriteria.sources`
+  * `ExclusionGrounds.sources`
+* Add `sources.csv` codelist
 
 ### 2023-08-01
 

--- a/codelists/sources.csv
+++ b/codelists/sources.csv
@@ -1,4 +1,4 @@
 Code,Title,Description
 epo-notice,Notice,Notice
-epo-procurement-document,Procurement Document,Procurement document
-epo-sub-espd,European Single Procurement Document (ESPD),European single procurement document
+epo-procurement-document,Procurement Document,Procurement Document
+epo-sub-espd,European Single Procurement Document (ESPD),European Single Procurement Document (ESPD)

--- a/codelists/sources.csv
+++ b/codelists/sources.csv
@@ -1,0 +1,4 @@
+Code,Title,Description
+epo-notice,Notice,Notice
+epo-procurement-document,Procurement Document,Procurement document
+epo-sub-espd,European Single Procurement Document (ESPD),European single procurement document

--- a/extension.json
+++ b/extension.json
@@ -19,7 +19,8 @@
     "+itemClassificationScheme.csv",
     "+milestoneType.csv",
     "+partyRole.csv",
-    "+relatedProcessScheme.csv"
+    "+relatedProcessScheme.csv",
+    "sources.csv"
   ],
   "contactPoint": {
     "name": "Open Contracting Partnership",

--- a/release-schema.json
+++ b/release-schema.json
@@ -201,7 +201,7 @@
       "properties": {
         "sources": {
           "title": "Sources",
-          "description": "The sources where the exclusion grounds are defined.",
+          "description": "The sources in which the exclusion grounds are defined.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Source"
@@ -216,7 +216,7 @@
       "properties": {
         "sources": {
           "title": "Sources",
-          "description": "The sources where the selection criteria are defined.",
+          "description": "The sources in which the selection criteria are defined.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Source"

--- a/release-schema.json
+++ b/release-schema.json
@@ -196,6 +196,48 @@
           "minLength": 1
         }
       }
+    },
+    "ExclusionGrounds": {
+      "properties": {
+        "sources": {
+          "title": "Sources",
+          "description": "The sources where the exclusion grounds are defined.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Source"
+          },
+          "wholeListMerge": true,
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      }
+    },
+    "SelectionCriteria": {
+      "properties": {
+        "sources": {
+          "title": "Sources",
+          "description": "The sources where the selection criteria are defined.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Source"
+          },
+          "wholeListMerge": true,
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      }
+    },
+    "Source": {
+      "title": "Source",
+      "description": "Where the criteria are defined.",
+      "type": "string",
+      "codelist": "sources.csv",
+      "openCodelist": false,
+      "enum": [
+        "epo-notice",
+        "epo-procurement-document",
+        "epo-sub-espd"
+      ]
     }
   }
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -204,9 +204,15 @@
           "description": "The sources in which the exclusion grounds are defined.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Source"
+            "type": "string",
+            "enum": [
+              "epo-notice",
+              "epo-procurement-document",
+              "epo-sub-espd"
+            ]
           },
-          "wholeListMerge": true,
+          "codelist": "sources.csv",
+          "openCodelist": false,
           "uniqueItems": true,
           "minItems": 1
         }
@@ -219,25 +225,19 @@
           "description": "The sources in which the selection criteria are defined.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Source"
+            "type": "string",
+            "enum": [
+              "epo-notice",
+              "epo-procurement-document",
+              "epo-sub-espd"
+            ]
           },
-          "wholeListMerge": true,
+          "codelist": "sources.csv",
+          "openCodelist": false,
           "uniqueItems": true,
           "minItems": 1
         }
       }
-    },
-    "Source": {
-      "title": "Source",
-      "description": "Where the criteria are defined.",
-      "type": "string",
-      "codelist": "sources.csv",
-      "openCodelist": false,
-      "enum": [
-        "epo-notice",
-        "epo-procurement-document",
-        "epo-sub-espd"
-      ]
     }
   }
 }


### PR DESCRIPTION
….sources

closes https://github.com/open-contracting/ocds-extensions/issues/230

Found https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/document-used-in-public-procurement, should this be referenced in either the description of `Source` or in the codelist?