### PR TITLE
Add RelatedProcess.part, update +relatedProcessScheme.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,10 @@ For complete guidance on meeting the disclosure requirements of European law, se
     {
       "id": "1",
       "identifier": "123e4567-e89b-12d3-a456-426614174000",
+      "part": "PAR-0001",
       "scheme": "eu-oj",
       "relationship": [
-        "prior"
+        "planning"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ For complete guidance on meeting the disclosure requirements of European law, se
   "relatedProcesses": [
     {
       "id": "1",
-      "identifier": "123e4567-e89b-12d3-a456-426614174000",
+      "identifier": "123e4567-e89b-12d3-a456-426614174000-06",
       "part": "PAR-0001",
-      "scheme": "eu-oj",
+      "scheme": "eu-notice-id-ref",
       "relationship": [
         "planning"
       ]
@@ -159,6 +159,14 @@ For complete guidance on meeting the disclosure requirements of European law, se
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2025-02-04
+
+* Add `RelatedProcess.part` field.
+* `+relatedProcessScheme.csv`:
+  * Add 'eu-notice-id-ref'
+  * Add 'eu-ojs-notice-id'
+  * Remove 'eu-oj'
 
 ### 2024-10-18
 

--- a/codelists/+relatedProcessScheme.csv
+++ b/codelists/+relatedProcessScheme.csv
@@ -1,2 +1,3 @@
 Code,Title,Description
-eu-oj,Official Journal of the European Union,An Official Journal of the European Union contracting process identifier.
+eu-notice-id-ref,eForms versioned notice identifier,An eForms notice identifier (UUID) concatenated with the associated version identifier (2 digits) in the form {UUID}-{vv}.
+eu-ojs-notice-id,Official Journal of the European Union notice identifier,"An Official Journal of the European Union notice identifier, also known as a Notice Publication ID in eForms."

--- a/release-schema.json
+++ b/release-schema.json
@@ -116,6 +116,19 @@
         }
       }
     },
+    "RelatedProcess": {
+      "properties": {
+        "part": {
+          "title": "Part",
+          "description": "The identifier of a part of a prior information notice, or another similar notice, that describes a planning process.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        }
+      }
+    },
     "LegislativeReference": {
       "title": "Legislative reference",
       "description": "Legislative reference and associated contact point",


### PR DESCRIPTION
Related to https://github.com/open-contracting/european-union-support/issues/238

Tests fail because an old changelog entry mentions 'eu-oj' which no longer appears in `+relatedProcessScheme.csv`.